### PR TITLE
feature/discord auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,9 @@
-# Since the ".env" file is gitignored, you can use the ".env.example" file to
-# build a new ".env" file when you clone the repo. Keep this file up-to-date
-# when you add new variables to `.env`.
-
-# This file will be committed to version control, so make sure not to have any
-# secrets in it. If you are cloning this repo, create a copy of this file named
-# ".env" and populate it with your secrets.
-
-# When adding additional environment variables, the schema in "/src/env.mjs"
-# should be updated accordingly.
-
-# Prisma
-# https://www.prisma.io/docs/reference/database-reference/connection-urls#env
+# === DO NOT PUT REAL VALUES IN THIS FILE === #
+# Use this file as a template of what's necessary in your local .env file.
 DATABASE_URL="file:./db.sqlite"
-
-# Next Auth
-# You can generate a new secret on the command line with:
-# openssl rand -base64 32
-# https://next-auth.js.org/configuration/options#secret
-# NEXTAUTH_SECRET=""
+# generate with `openssl rand -base64 32`
+NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
-
-# Next Auth Discord Provider
+# Ask Aaron for info
 DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""


### PR DESCRIPTION
## Description

Add Discord auth so users can sign in with their Discord accounts.

### Solution

To start I setup an application under my personal Discord account. Once the application was setup we needed to get the `Client ID` and `Client Secret` for the Discord app and add them to the Movie Night app's `.env` file.

Additionally, I added a callback URL to the Discord app of `http://localhost:3000/api/auth/callback/discord` which is a local URL on the Movie Night application which Discord can route back to once signing in the user. This local route will then handle the response from Discord and decide whether the user is successfully signed in or not.

To make this app more production like in the future we should create a new Discord account to manage this application only. We will also need to add callback URLs for every environment. We can cross this bridge when we get there though :)

### Test Considerations

- User is able to sign in and out of their Discord account successfully

closes #2 